### PR TITLE
Improvements for HTML5/XHTML specifications.

### DIFF
--- a/website/index.html
+++ b/website/index.html
@@ -126,7 +126,7 @@
 
 	<p>Comments are welcome. Send an email to <a href="mailto:FIXME"><span class="caps">FIXME</span> full name</a> email via the <a href="http://groups.google.com/group/starling">forum</a></p>
     <p class="coda">
-      <a href="FIXME email">FIXME full name</a>, 4th November 2007<br>
+      <a href="FIXME email">FIXME full name</a>, 4th November 2007<br/>
       Theme extended from <a href="http://rb2js.rubyforge.org/">Paul Battley</a>
     </p>
 </div>


### PR DESCRIPTION
**Introduction:**
In accordance with the w3 HTML5 specification for HTML code, void tags (see reference) should be marked as self-closing. During a scan for repositories containing HTML files, we found HTML code in your repository that needed this improvement.

Even though the self-closing specification is not a strict requirement by web-browsers, and they will happily parse the tags anyhow - that is not an excuse for not writing specification valid code. And given the spirit of open-source community, I will be more than happy to push these improvements to you. The changes in this Pull-Request will not break your HTML code, and they have also been manually inspected, to ensure the only change is closing of void elements.

**References:**
https://www.w3.org/TR/html5/syntax.html#void-elements
